### PR TITLE
Add Element ID parameter for text-input-field ...

### DIFF
--- a/library.json
+++ b/library.json
@@ -3,7 +3,7 @@
   "description": "A configurable editor element that can be used to describe an input field.",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 5,
+  "patchVersion": 6,
   "runnable": 0,
   "author": "Joubel",
   "license": "MIT",

--- a/semantics.json
+++ b/semantics.json
@@ -58,5 +58,13 @@
     "default": false,
     "optional": true,
     "description": "Check to make this field required, the user must answer all required fields to be able to export a document."
+  },
+  {
+    "name": "elementId",
+    "label": "Element ID",
+    "type": "text",
+    "description": "Unique element ID that can be used to retrieve its value.",
+    "importance": "low",
+    "optional": true
   }
 ]

--- a/text-input-field.js
+++ b/text-input-field.js
@@ -76,7 +76,8 @@ H5P.TextInputField = (function ($) {
     // Remove trailing newlines
     return {
       description: this.params.taskDescription.replace(/^\s+|\s+$/g, '').replace(/(<p>|<\/p>)/img, ""),
-      value: this.$inputField.val()
+      value: this.$inputField.val(),
+      elementId: this.params.elementId
     };
   };
 


### PR DESCRIPTION
Add Element ID parameter for text-input-field so that its value can be retrieved at a later time for the custom template functionality in Document Export Page